### PR TITLE
ci: Add manifest

### DIFF
--- a/.github/workflows/vaccel-build-and-upload.yml
+++ b/.github/workflows/vaccel-build-and-upload.yml
@@ -5,114 +5,168 @@ on:
     branches: [ '*\+vaccel' ]
 
   workflow_dispatch:
+    inputs:
+      registry:
+        default: 'harbor.nbfc.io'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  REGISTRY: harbor.nbfc.io/nubificus
-  IMAGE_NAME: qemu-vaccel
-  APP: qemu-vaccel
+  REGISTRY: ${{ github.event.inputs.registry || 'harbor.nbfc.io' }}
+  # NOTE: We assume that a project named after the repo owner exists in the
+  # registry. The image will be uploaded as <repo_name> under the <repo_owner>
+  # project.
+  REGISTRY_IMAGE: ${{ github.event.inputs.registry || 'harbor.nbfc.io' }}/${{ github.repository }}
+  RUNNER_ARCH_MAP: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
 
 jobs:
   build:
     name: Build Docker Image
-    runs-on: [self-hosted, gcc, lite, "${{ matrix.arch }}"]
+    runs-on: ${{ format('{0}-{1}', 'base-dind-2204', matrix.arch) }}
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        arch: ["arm64", "amd64"]
     outputs:
-      digest-x86_64: ${{ steps.set-outputs.outputs.digest-x86_64 }}
-      digest-aarch64: ${{ steps.set-outputs.outputs.digest-aarch64 }}
+      digest-amd64: ${{ steps.set-outputs.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.set-outputs.outputs.digest-arm64 }}
+
     steps:
-    - name: Cleanup previous jobs
-      run: |
-        echo "Cleaning up previous runs"
-        sudo rm -rf ${{ github.workspace }}/*
-        sudo rm -rf ${{ github.workspace }}/.??*
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Login to registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HARBOR_USER }}
+          password: ${{ secrets.HARBOR_SECRET }}
 
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.HARBOR_USER }}
-        password: ${{ secrets.HARBOR_PASSWD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=raw,value=${{ matrix.arch }}
-          type=sha,prefix=${{ matrix.arch }}-
-          type=sha,format=long,prefix=${{ matrix.arch }}-
-          type=ref,event=branch,prefix=${{ matrix.arch }}-
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=sha,prefix=${{ matrix.arch }}-
+            type=ref,event=branch,prefix=${{ matrix.arch }}-
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Build and push ${{ matrix.arch }} image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./subprojects/vaccel/docker
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          provenance: false
+          build-args: |
+            ARCHTAG=${{ fromJson(env.RUNNER_ARCH_MAP)[0][matrix.arch] }}
+            BRANCH=${{ github.event.ref_name || github.ref_name }}
 
-    - name: Build and push Docker image
-      id: build-and-push
-      uses: docker/build-push-action@v6
-      with:
-        context: ./subprojects/vaccel/docker
-        no-cache: true
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          ARCHTAG=${{ matrix.arch }}
-          BRANCH=${{ github.event.ref_name || github.ref_name }}
+      - name: Set ${{ matrix.arch }} digest output
+        id: set-outputs
+        run: |
+          # Workaround for https://github.com/actions/runner/issues/2499
+          echo "digest-${{ matrix.arch }}=${{ steps.build-and-push.outputs.digest }}" \
+            >> "$GITHUB_OUTPUT"
+        shell: bash
 
-    - name: Set per-arch outputs
-      id: set-outputs
-      run: |
-        # Workaround for https://github.com/actions/runner/issues/2499
-        echo "digest-${{ matrix.arch }}=${{ steps.build-and-push.outputs.digest }}" \
-          >> "$GITHUB_OUTPUT"
+  create-manifest:
+    name: Create Merged Docker Image Manifest
+    needs: [build]
+    runs-on: 'base-dind-2204-amd64'
+    outputs:
+      digest-merged: ${{ steps.inspect.outputs.digest-merged }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Login to registry ${{ inputs.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HARBOR_USER }}
+          password: ${{ secrets.HARBOR_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest
+
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< \
+            "$DOCKER_METADATA_OUTPUT_JSON") \
+            ${{ env.REGISTRY_IMAGE }}@${{ needs.build.outputs.digest-amd64 }} \
+            ${{ env.REGISTRY_IMAGE }}@${{ needs.build.outputs.digest-arm64 }}
+        shell: bash
+
+      - name: Inspect merged image
+        id: inspect
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          digest=$(docker buildx imagetools inspect \
+            ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }} \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          if [[ -z "${digest}" ]]; then
+            echo "Could not get merged image digest"
+            exit 1
+          fi
+          echo "digest-merged=${digest}" >> "$GITHUB_OUTPUT"
+        shell: bash
 
   sign:
-    name: Sign Docker Image
-    runs-on: [self-hosted]
-    needs: [build]
-    strategy:
-      matrix:
-        arch: [x86_64, aarch64]
+    name: Sign Docker Images
+    needs: [build, create-manifest]
+    runs-on: 'base-dind-2204-amd64'
     permissions:
       contents: read
       id-token: write
 
     steps:
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.6.0
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
 
-    - name: Check install
-      run: cosign version
+      - name: Verify Cosign installation
+        run: cosign version
 
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.HARBOR_USER }}
-        password: ${{ secrets.HARBOR_PASSWD }}
+      - name: Login to registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HARBOR_USER }}
+          password: ${{ secrets.HARBOR_SECRET }}
 
-    - name: Sign published Docker image
-      env:
-        DIGEST: ${{ needs.build.outputs[format('digest-{0}', matrix.arch)] }}
-      run: |
-        cosign sign --yes ${{ env.REGISTRY }}/${{ env.APP }}@${{ env.DIGEST }} \
-        -a "repo=${{ github.repository }}" \
-        -a "workflow=${{ github.workflow }}" \
-        -a "ref=${{ github.sha }}" \
-        -a "author=Nubificus LTD"
-
-    - name: Cleanup previous runs
-      if: ${{ always() }}
-      run: |
-        sudo rm -rf ${{ github.workspace }}/*
-        sudo rm -rf ${{ github.workspace }}/.??*
+      - name: Sign published Docker images
+        env:
+          DIGESTS: >-
+            ${{ needs.create-manifest.outputs.digest-merged }}
+            ${{ needs.build.outputs.digest-amd64 }}
+            ${{ needs.build.outputs.digest-arm64 }}
+        run: |
+          for digest in ${DIGESTS}; do
+            cosign sign --yes ${{ env.REGISTRY_IMAGE }}@${digest} \
+              -a "repo=${{ github.repository }}" \
+              -a "workflow=${{ github.workflow }}" \
+              -a "ref=${{ github.sha }}" \
+              -a "author=Nubificus LTD"
+          done
+        shell: bash


### PR DESCRIPTION
Add a workflow that enables the following structure to our `qemu-vaccel`
container images:

`registry/qemu-vaccel:ARCH1-DIGEST` |->
`registry/qemu-vaccel:ARCH2-DIGEST` |-> `registry/qemu-vaccel:DIGEST`
`registry/qemu-vaccel:ARCH3-DIGEST` |->
